### PR TITLE
Check for gmp dependency to build with encrypted UAM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Time Capsule products as well as other NAS devices from various vendors.
 This project uses the Meson build system with a Ninja backend.
 First off, make sure `meson` and `ninja` (sometimes packaged as `ninja-build`) are installed.
 
-Mandatory dependencies include `gmp` and `pthread`. The `libgcrypt` library is optional,
+The mandatory dependency is `pthread`.
+
+The `libgcrypt`  and `gmp` libraries are optional,
 and will be used for encrypted password authentication (DHX2, DHCAST128, RandNum UAMs.)
 
 For the CLI client, `ncurses` and `libreadline` are required.

--- a/meson.build
+++ b/meson.build
@@ -30,10 +30,12 @@ pthread_dep = cc.find_library('pthread', dirs: libsearch_dirs, required: true)
 libiconv_dep = cc.find_library('iconv', dirs: libsearch_dirs, required: false)
 
 gcrypt_dep = dependency('libgcrypt', version: '>=1.2.3', required: false)
+libgmp_dep = dependency('gmp', required: false)
 fuse_dep = cc.find_library('fuse', dirs: libsearch_dirs, required: false)
 
 with_afpcmd = ncurses_dep.found() and readline_dep.found()
 with_fuse = get_option('enable-fuse') and fuse_dep.found()
+with_crypt = gcrypt_dep.found() and libgmp_dep.found()
 
 if with_fuse
   cflags += [
@@ -44,7 +46,7 @@ endif
 
 incdir = include_directories(['.', 'include', include_dirs])
 
-if gcrypt_dep.found()
+if with_crypt
   add_project_arguments('-DHAVE_LIBGCRYPT', language: 'c')
 endif
 
@@ -86,6 +88,6 @@ summary(summary_info, bool_yn: true, section: 'Compilation:')
 summary_info = {
     'AFP CLI client': with_afpcmd,
     'AFP FUSE client': with_fuse,
-    'DHX2 / DHX UAM support': gcrypt_dep.found(),
+    'DHX2 / DHX UAM support': with_crypt,
 }
 summary(summary_info, bool_yn: true, section: 'Options:')


### PR DESCRIPTION
The gmp dependency is a prerequisite for DHX/DHX2/RandNum UAM auth support.