### PR TITLE
Remove obsolete Linux compat code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,35 @@ jobs:
       - name: Uninstall
         run: sudo ninja -C build uninstall
 
+  build-alpine:
+    name: Alpine
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apk add --no-cache \
+            build-base \
+            fuse-dev \
+            gmp-dev \
+            libgcrypt-dev \
+            meson \
+            ncurses-dev \
+            ninja \
+            readline-dev
+      - name: Setup
+        run: meson setup build --prefix=/usr
+      - name: Compile
+        run: meson compile -C build
+      - name: Install
+        run: meson install -C build
+      - name: Run
+        run: afpcmd -h
+      - name: Uninstall
+        run: ninja -C build uninstall
+
   build-macos:
     name: macOS
     runs-on: macos-latest

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -36,7 +36,7 @@
 #include "fuse_error.h"
 #include "fuse_internal.h"
 
-#ifdef __linux
+#ifdef __linux__
 #define FUSE_DEVICE "/dev/fuse"
 #elif defined(__APPLE__)
 #define FUSE_DEVICE "/dev/macfuse0"

--- a/fuse/fuse_int.c
+++ b/fuse/fuse_int.c
@@ -1,5 +1,3 @@
-
-
 /*
 
     fuse.c, FUSE interfaces for afpfs-ng
@@ -26,11 +24,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
-#ifdef __linux__
-#include <asm/fcntl.h>
-#else
 #include <fcntl.h>
-#endif
 
 #include <utime.h>
 #include <stdlib.h>

--- a/include/libafpclient.h
+++ b/include/libafpclient.h
@@ -4,6 +4,7 @@
 
 #include <unistd.h>
 #include <syslog.h>
+#include <sys/select.h>
 
 #define MAX_CLIENT_RESPONSE 2048
 

--- a/lib/lowlevel.c
+++ b/lib/lowlevel.c
@@ -207,13 +207,8 @@ int ll_open(struct afp_volume * volume, const char *path, int flags,
 	   O_NOATIME - we have no way to handle this anyway
 	*/
 
-
 	/*this will be used later for caching*/
-#ifdef __linux__
-	fp->sync=((unsigned char)(flags & (O_SYNC | O_DIRECT)));  
-#else
-	fp->sync=(flags & (O_SYNC));  
-#endif
+	fp->sync=(unsigned char) (flags & (O_SYNC));
 
 	/* See if we need to create the file  */
 	if (aflags & AFP_OPENFORK_ALLOWWRITE) {
@@ -231,11 +226,7 @@ int ll_open(struct afp_volume * volume, const char *path, int flags,
 		} 
 	}
 
-	if (
-#ifdef __linux__
-		(flags & O_LARGEFILE) && 
-#endif
-		(volume->server->using_version->av_number<30)) 
+	if (volume->server->using_version->av_number<30)
 	{
 		switch(ll_get_directory_entry(volume,fp->basename,fp->did,
 			kFPParentDirIDBit|kFPNodeIDBit|
@@ -627,7 +618,6 @@ int ll_getattr(struct afp_volume * volume, const char *path, struct stat *stbuf,
 #endif
 
 	return 0;
-
 }
 
 
@@ -635,7 +625,6 @@ int ll_write(struct afp_volume * volume,
 		const char *data, size_t size, off_t offset,
                   struct afp_file_info * fp, size_t * totalwritten)
  {
-
 	int ret,err=0;
 	uint64_t sizetowrite, ignored;
 	uint32_t ignored32;

--- a/lib/lowlevel.c
+++ b/lib/lowlevel.c
@@ -12,11 +12,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>
-#ifdef __linux__
-#include <asm/fcntl.h>
-#else
 #include <fcntl.h>
-#endif
 #include "afp.h"
 #include "afp_protocol.h"
 #include "codepage.h"

--- a/lib/midlevel.c
+++ b/lib/midlevel.c
@@ -1,5 +1,3 @@
-
-
 /*
     midlevel.c: some funtions to abstract some of the common functions 
 
@@ -19,12 +17,7 @@
 #include <sys/time.h>
 #include <time.h>
 
-#ifdef __linux__
-#include <asm/fcntl.h>
-#else
 #include <fcntl.h>
-#endif
-
 
 #include "users.h"
 #include "did.h"


### PR DESCRIPTION
Eliminating most Linux compat code which seems outdated to me.

Especially suspicious of this section.

```
#ifdef __linux__
	fp->sync=((unsigned char)(flags & (O_SYNC | O_DIRECT)));  
#else
	fp->sync=(flags & (O_SYNC));  
#endif
```

Some random reading online suggests O_DIRECT should not be combined with fork()... which I think we have on our codepath here.