### PR TITLE
build with c11 standard

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'c',
   version: '0.8.2',
   license: 'GPLv2',
-  default_options: ['warning_level=3', 'c_std=gnu99'],
+  default_options: ['warning_level=3', 'c_std=c11'],
   meson_version: '>=0.61',
 )
 


### PR DESCRIPTION
After flagging the project as D_GNU_SOURCE, it compiles cleanly as c11.

And, avoids this on FreeBSD

```

  [39/49] Compiling C object fuse/mount_afpfs.p/client.c.o
  ../fuse/client.c:84:14: warning: '_Generic' is a C11 extension [-Wc11-extensions]
     84 |                                         (char *)basename(thisbin),AFPFSD_FILENAME);
        |                                                 ^
  /usr/include/libgen.h:60:21: note: expanded from macro 'basename'
     60 | #define basename(x)     __generic(x, const char *, __old_basename, basename)(x)
        |                         ^
  /usr/include/sys/cdefs.h:314:2: note: expanded from macro '__generic'
    314 |         _Generic(expr, t: yes, default: no)
        |         ^
  1 warning generated.
```