### PR TITLE
define more magic numbers as global constants

### DIFF
--- a/TODO
+++ b/TODO
@@ -135,12 +135,6 @@ Packaging and polish:
 
 Other
   - rewrite pick_version to do more intelligent guessing for a version number
-  - right now, there's a hard coded 1024 in afp_write().  See how the Mac OS
-    client works.
   - after many operations, commands no longer work and neither does ^c
-  - fix FUSE_USE_VERSION definition
-  - stop using MAX_PATH, since this is server-specific
   - document API
   - shutting down notices aren't honoured
-
-

--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -20,6 +20,8 @@
 #include <limits.h>
 #include <ctype.h>
 
+#include "libafpclient.h"
+#include "cmdline_afp.h"
 #include "cmdline_main.h"
 
 static char curdir[AFP_MAX_PATH];
@@ -196,12 +198,11 @@ static void print_file_details(struct afp_file_info * p)
 
 static int connect_volume(char * volumename)
 {
-
 	if (strlen(volumename)==0) goto error;
 
 	/* Ah, we're not connected to a volume*/
 	unsigned int len=0;
-	char mesg[1024];
+	char mesg[MAX_ERROR_LEN];
 
 	if ((vol = find_volume_by_name(server,volumename))==NULL) 
 	{
@@ -211,7 +212,7 @@ static int connect_volume(char * volumename)
 	vol->mapping= AFP_MAPPING_LOGINIDS;
 	vol->extra_flags |= VOLUME_EXTRA_FLAGS_NO_LOCKING;
 
-	if (afp_connect_volume(vol,server,mesg,&len,1024 ))
+	if (afp_connect_volume(vol,server,mesg,&len,MAX_ERROR_LEN ))
 	{
 		printf("Could not access volume %s\n",
 			vol->volume_name);
@@ -229,7 +230,6 @@ static int server_subconnect(void)
 {
 	struct afp_connection_request * conn_req;
 
-#define BUFFER_SIZE 2048
 	conn_req = malloc(sizeof(struct afp_connection_request));
 	if(!conn_req)
 		return -1;
@@ -367,8 +367,8 @@ int com_dir(char * arg)
 	}
 
 	if (strlen(url.volumename)==0) {
-		char names[1024];
-		afp_list_volnames(server,names,1024);
+		char names[VOLNAME_LEN];
+		afp_list_volnames(server,names,VOLNAME_LEN);
 		printf("You're not connected to a volume, choose from %s\n",
 			names);
 		goto out;
@@ -1182,8 +1182,8 @@ static void * cmdline_server_startup(int recursive)
 	if (server_subconnect()) goto error;
 
 	if (strlen(url.volumename)==0) {
-		char names[1024];
-		afp_list_volnames(server,names,1024);
+		char names[VOLNAME_LEN];
+		afp_list_volnames(server,names,VOLNAME_LEN);
 		printf("Specify a volume with 'cd volume'. Choose one of: %s\n",
 			names);
 		trigger_connected();

--- a/cmdline/cmdline_afp.h
+++ b/cmdline/cmdline_afp.h
@@ -30,4 +30,6 @@ void cmdline_afp_exit(void);
 int cmdline_afp_setup(int recursive, char * url_string);
 void cmdline_afp_setup_client(void);
 
+#define ARG_LEN 1024
+
 #endif

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -17,7 +17,9 @@
 #include <getopt.h>
 #include <ctype.h>
 #include <signal.h>
+
 #include "afp.h"
+#include "libafpclient.h"
 #include "cmdline_afp.h"
 #include "cmdline_testafp.h"
 
@@ -315,7 +317,6 @@ static int execute_line (char * line)
 void * cmdline_ui(__attribute__ ((unused)) void * other)
 {
 	char * line;
-#define ARG_LEN 1024
 	char * s, s2[ARG_LEN];
 
 	while (running)  {

--- a/cmdline/getstatus.c
+++ b/cmdline/getstatus.c
@@ -9,6 +9,7 @@
 #include <netinet/in.h>
 
 #include "afp.h"
+#include "afp_protocol.h"
 
 #define FLAG_COUNT 16
 
@@ -60,7 +61,7 @@ void draw_icon(int offset, char icon[])
     int i, j;
 
     // icons are 32x32 bitmaps; 128-byte icon + 128-byte mask
-    for (i = 0; i < 256; i++)
+    for (i = 0; i < AFP_SERVER_ICON_LEN; i++)
     {
         char c = icon[i + offset];
         

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -332,15 +332,14 @@ static void * start_fuse_thread(void * other)
 
 static int volopen(struct fuse_client * c, struct afp_volume * volume)
 {
-	char mesg[1024];
+	char mesg[MAX_ERROR_LEN];
 	unsigned int l = 0;	
-	memset(mesg,0,1024);
-	int rc=afp_connect_volume(volume,volume->server,mesg,&l,1024);
+	memset(mesg,0,MAX_ERROR_LEN);
+	int rc=afp_connect_volume(volume,volume->server,mesg,&l,MAX_ERROR_LEN);
 
 	log_for_client((void *) c,AFPFSD,LOG_ERR,mesg);
 
 	return rc;
-
 }
 
 
@@ -372,7 +371,7 @@ static unsigned char process_suspend(struct fuse_client * c)
 
 static int afp_server_reconnect_loud(struct fuse_client * c, struct afp_server * s) 
 {
-	char mesg[1024];
+	char mesg[MAX_ERROR_LEN];
 	unsigned int l = 2040;
 	int rc;
 
@@ -382,8 +381,6 @@ static int afp_server_reconnect_loud(struct fuse_client * c, struct afp_server *
                 log_for_client((void *) c,AFPFSD,LOG_ERR,
                         "%s",mesg);
 	return rc;
-
-
 }
 
 
@@ -728,8 +725,8 @@ static struct afp_volume * mount_volume(struct fuse_client * c,
 			"Volume %s does not exist on server %s.\n",volname,
 			server->server_name_printable);
 		if (server->num_volumes) {
-			char names[1024];
-			afp_list_volnames(server,names,1024);
+			char names[VOLNAME_LEN];
+			afp_list_volnames(server,names,VOLNAME_LEN);
 			log_for_client((void *)c,AFPFSD,LOG_ERR,
 				"Choose from: %s\n",names);
 		}

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -21,6 +21,7 @@
 #include <getopt.h>
 #include <signal.h>
 #include <sys/socket.h>
+#include <fuse.h>
 
 #include "afp.h"
 #include "dsi.h"
@@ -40,10 +41,6 @@
 #else
 #define FUSE_DEVICE "/dev/fuse"
 #endif
-
-# define FUSE_USE_VERSION 29
-
-#include <fuse.h>
 
 static int fuse_log_method=LOG_METHOD_SYSLOG;
 

--- a/fuse/daemon.c
+++ b/fuse/daemon.c
@@ -22,13 +22,9 @@
 #include <time.h>
 #include <utime.h>
 #include <unistd.h>
-
-#define FUSE_USE_VERSION 29
-
 #include <fuse.h>
 
 #include "afp.h"
-
 #include "dsi.h"
 #include "afp_server.h"
 #include "utils.h"

--- a/fuse/daemon.c
+++ b/fuse/daemon.c
@@ -35,12 +35,6 @@
 #include "daemon.h"
 #include "commands.h"
 
-#define MAX_ERROR_LEN 1024
-#define STATUS_LEN 1024
-
-
-#define MAX_CLIENT_RESPONSE 2048
-
 
 static int debug_mode = 0;
 static char commandfilename[PATH_MAX];

--- a/fuse/daemon.h
+++ b/fuse/daemon.h
@@ -1,7 +1,6 @@
 #ifndef __DAEMON_H_
 #define __DAEMON_H_
 
-
 void rm_fd_and_signal(int fd);
 void signal_main_thread(void);
 
@@ -12,6 +11,7 @@ int process_client_fds(fd_set * set, int max_fd, int ** onfd);
 int fuse_unmount_volume(struct afp_volume * volume);
 void fuse_forced_ending_hook(void);
 
-
+#define STATUS_LEN 1024
+#define MAX_CLIENT_RESPONSE 2048
 
 #endif

--- a/fuse/fuse_error.c
+++ b/fuse/fuse_error.c
@@ -14,7 +14,7 @@ static fpos_t pos;
 
 void report_fuse_errors(struct fuse_client * c)
 {
-	char buf[1024];
+	char buf[MAX_ERROR_LEN];
         int fd;
 	int len;
 
@@ -24,10 +24,10 @@ void report_fuse_errors(struct fuse_client * c)
 	clearerr(stderr);
 	fsetpos(stderr, &pos);        /* for C9X */
 
-        if ((fd=open(TMP_FILE,O_RDONLY))<0) return;;
-        memset(buf,0,1024);
-        len=read(fd,buf,1024);
-        close(fd);
+	if ((fd=open(TMP_FILE,O_RDONLY))<0) return;;
+	memset(buf,0,MAX_ERROR_LEN);
+	len=read(fd,buf,MAX_ERROR_LEN);
+	close(fd);
 
 	unlink(TMP_FILE);
 
@@ -43,4 +43,3 @@ void fuse_capture_stderr_start(void)
 	captured_fd = dup(fileno(stderr));
 	freopen(TMP_FILE, "a", stderr);
 }
-

--- a/fuse/fuse_int.c
+++ b/fuse/fuse_int.c
@@ -13,11 +13,6 @@
 
 #define HAVE_ARCH_STRUCT_FLOCK
 
-#ifndef FUSE_USE_VERSION
-#	define FUSE_USE_VERSION 29
-#endif
-
-
 #include "afp.h"
 
 #include <fuse.h>

--- a/fuse/fuse_int.h
+++ b/fuse/fuse_int.h
@@ -1,8 +1,5 @@
 #ifndef __FUSE_INT_H_
 #define __FUSE_INT_H_
 
-
-
 int afp_register_fuse(int fuseargc, char *fuseargv[],struct afp_volume * vol);
 #endif
-

--- a/fuse/fuse_internal.h
+++ b/fuse/fuse_internal.h
@@ -3,7 +3,6 @@
 
 #define AFP_CLIENT_INCOMING_BUF 2048+256
 
-
 struct fuse_client {
 	char incoming_string[AFP_CLIENT_INCOMING_BUF];
 	int incoming_size;

--- a/include/afp.h
+++ b/include/afp.h
@@ -7,13 +7,13 @@
 #include <netdb.h>
 #include <sys/statvfs.h>
 #include <pwd.h>
-#include "afp_protocol.h"
-#include "libafpclient.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <netinet/in.h>
 
+#include "afp_protocol.h"
+#include "libafpclient.h"
 
 #define AFPFS_VERSION "0.8.2"
 
@@ -161,7 +161,7 @@ extern struct afp_versions afp_versions[];
 struct afp_server_basic {
        char server_name_printable[AFP_SERVER_NAME_UTF8_LEN];
        char machine_type[AFP_MACHINETYPE_LEN];
-       char icon[256];
+       char icon[AFP_SERVER_ICON_LEN];
        char signature[AFP_SIGNATURE_LEN];
        unsigned char versions[SERVER_MAX_VERSIONS];
        unsigned int supported_uams;
@@ -204,7 +204,7 @@ struct afp_server {
         char server_name_printable[AFP_SERVER_NAME_UTF8_LEN];
 
 	char machine_type[17];
-	char icon[256];
+	char icon[AFP_SERVER_ICON_LEN];
 	char signature[16];
 	unsigned short flags;
 	int connect_state;

--- a/include/afp_protocol.h
+++ b/include/afp_protocol.h
@@ -26,7 +26,6 @@
 
 #define AFP_SERVER_ICON_LEN 256
 
-
 #define AFP_MAX_USERNAME_LEN 127
 #define AFP_MAX_PASSWORD_LEN 127
 
@@ -355,7 +354,3 @@ enum {
 
 
 #endif
-
-
-
-

--- a/include/dsi.h
+++ b/include/dsi.h
@@ -35,5 +35,6 @@ int dsi_recv(struct afp_server * server);
 #define DSI_OPENVOLUME_TIMEOUT 20
 #define DSI_LOGIN_TIMEOUT 20
 
+#define GETSTATUS_BUF_SIZE 1024
 
 #endif

--- a/include/libafpclient.h
+++ b/include/libafpclient.h
@@ -28,19 +28,18 @@ struct libafpclient {
 extern struct libafpclient * libafpclient;
 
 void libafpclient_register(struct libafpclient * tmpclient);
-
-
 void signal_main_thread(void);
 
 /* These are logging functions */
 
 #define MAXLOGSIZE 2048
+#define MAX_ERROR_LEN 1024
+#define VOLNAME_LEN 1024
 
 #define LOG_METHOD_SYSLOG 1
 #define LOG_METHOD_STDOUT 2
 
 void set_log_method(int m);
-
 
 void log_for_client(void * priv,
         enum loglevels loglevel, int logtype, char * message,...);

--- a/lib/afp_url.c
+++ b/lib/afp_url.c
@@ -145,7 +145,7 @@ static char * escape_strchr(const char * haystack, int c, const char * toescape)
 
 int afp_parse_url(struct afp_url * url, const char * toparse, int verbose)
 {
-	char firstpart[255],secondpart[2048];
+	char firstpart[AFP_HOSTNAME_LEN],secondpart[MAX_CLIENT_RESPONSE];
 	char *p, *q;
 	int firstpartlen;
 	int skip_earliestpart=0;

--- a/lib/log.c
+++ b/lib/log.c
@@ -9,10 +9,10 @@ void log_for_client(void * priv,
 	enum loglevels loglevel, int logtype, char *format, ...) {
 
 	va_list ap;
-	char new_message[1024];
+	char new_message[MAX_ERROR_LEN];
 
 	va_start(ap, format);
-	vsnprintf(new_message,1024,format,ap);
+	vsnprintf(new_message,MAX_ERROR_LEN,format,ap);
 	va_end(ap);
 
 	libafpclient->log_for_client(priv,loglevel,logtype,new_message);

--- a/lib/lowlevel.h
+++ b/lib/lowlevel.h
@@ -1,5 +1,9 @@
 #ifndef __LOWLEVEL_H_
 #define __LOWLEVEL_H_
+
+#include <sys/types.h>
+#include <stdint.h>
+
 int ll_get_directory_entry(struct afp_volume * volume,
         char * basename,
         unsigned int dirid,
@@ -32,4 +36,3 @@ int ll_open(struct afp_volume * volume, const char *path, int flags,
         struct afp_file_info *fp);
 
 #endif
-

--- a/lib/resource.c
+++ b/lib/resource.c
@@ -3,7 +3,9 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+
 #include "afp.h"
+#include "afp_protocol.h"
 #include "resource.h"
 #include "lowlevel.h"
 #include "did.h"
@@ -333,8 +335,8 @@ int appledouble_read(struct afp_volume * volume, struct afp_file_info *fp,
 			free(comment.data);
 			return ret;
 		case AFP_META_SERVER_ICON:
-			if (offset>256) return -EFAULT;
-			tocopy=min(size,(256-(unsigned long) offset));
+			if (offset>AFP_SERVER_ICON_LEN) return -EFAULT;
+			tocopy=min(size,(AFP_SERVER_ICON_LEN-(unsigned long) offset));
 			memcpy(buf+offset,volume->server->icon,tocopy);
 			*eof=1;
 			fp->eof=1;
@@ -484,7 +486,7 @@ int appledouble_getattr(struct afp_volume * volume,
 		}
 		case AFP_META_SERVER_ICON:
 			stbuf->st_mode = S_IFREG | 0444;
-			stbuf->st_size=256;
+			stbuf->st_size=AFP_SERVER_ICON_LEN;
 			goto okay;
 	}
 	return 0;

--- a/lib/server.c
+++ b/lib/server.c
@@ -32,8 +32,7 @@ struct afp_server * afp_server_complete_connection(
 {
 	char loginmsg[AFP_LOGINMESG_LEN];
 	int using_uam;
-#define LOGIN_ERROR_MESG_LEN 1024
-	char mesg[LOGIN_ERROR_MESG_LEN];
+	char mesg[MAX_ERROR_LEN];
 	unsigned int len=0;
 
 	memset(loginmsg,0,AFP_LOGINMESG_LEN);
@@ -61,7 +60,7 @@ struct afp_server * afp_server_complete_connection(
 	}
 	server->using_uam=using_uam;
 		
-	if (afp_server_login(server,mesg,&len,LOGIN_ERROR_MESG_LEN)) {
+	if (afp_server_login(server,mesg,&len,MAX_ERROR_LEN)) {
 		log_for_client(priv,AFPFSD,LOG_ERR,
 			"Login error: %s\n", mesg);
 		goto error;
@@ -89,11 +88,9 @@ struct afp_server * afp_server_complete_connection(
 
 	memcpy(server->loginmesg,loginmsg, AFP_LOGINMESG_LEN);
 
-
 	return server;
 error:
 	afp_server_remove(server);
 	return NULL;
 
 }
-


### PR DESCRIPTION
Reduce the reliance on magic numbers across the codebase. Use global defines in the various module headers instead.