### PR TITLE
enable extra debug logging at compile time

### DIFF
--- a/fuse/fuse_int.c
+++ b/fuse/fuse_int.c
@@ -41,10 +41,10 @@
 #include "midlevel.h"
 #include "fuse_error.h"
 
-/* Uncomment the following line to enable full debugging: */
-/*
+/* enable full debugging: */
+#ifdef DEBUG
 #define LOG_FUSE_EVENTS 
-*/
+#endif
 
 void log_fuse_event(__attribute__((unused)) enum loglevels loglevel, __attribute__((unused)) int logtype,
                     __attribute__((unused)) char *format, ...) {

--- a/lib/dsi.c
+++ b/lib/dsi.c
@@ -30,7 +30,9 @@
 #include "codepage.h"
 
 /* define this in order to get reams of DSI debugging information */
-#undef DEBUG_DSI
+#ifdef DEBUG
+#define DEBUG_DSI
+#endif
 
 static int dsi_remove_from_request_queue(struct afp_server *server,
 	struct dsi_request *toremove);

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,8 @@ project(
 
 cc = meson.get_compiler('c')
 host_os = host_machine.system()
+build_type = get_option('buildtype')
+
 install_prefix = get_option('prefix')
 bindir = install_prefix / get_option('bindir')
 libdir = install_prefix / get_option('libdir')
@@ -21,6 +23,10 @@ cflags = [
   '-D_FILE_OFFSET_BITS=64',
   '-D_GNU_SOURCE',
 ]
+
+if build_type == 'debug'
+    cflags += '-DDEBUG'
+endif
 
 if host_os in ['dragonfly', 'freebsd', 'openbsd']
     libsearch_dirs += '/usr/local/lib'
@@ -86,7 +92,7 @@ summary_info = {
     'Host CPU': host_machine.cpu_family(),
     'Host endianness': build_machine.endian(),
     'C compiler': cc.get_id(),
-    'Build stype': get_option('buildtype'),
+    'Build stype': build_type,
     'Shared or static libraries': get_option('default_library'),
 }
 summary(summary_info, bool_yn: true, section: 'Compilation:')


### PR DESCRIPTION
before, you had to edit the source code to enable DSI and FUSE verbose logging. This change puts it under the -DDEBUG C flag which is controlled by the meson build type (default is debug)