### PR TITLE
Read version string from build system, and bump to 0.9.0

### DIFF
--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -366,11 +366,12 @@ void cmdline_loop_started(void)
 static void usage(void)
 {
 	printf(
+"afpfs-ng %s - Apple Filing Protocol CLI client application\n"
 "afpcmd [-r] [url]\n"
-"     -r:   set the recursive flag\n"
-"     url:  an AFP url, in the form of:\n"
-"           afp://username;AUTH=authtype:password@server:548/volume/path\n"
-"See afpcmd(1) for more information.\n"
+"\t-r:   set the recursive flag\n"
+"\turl:  an AFP url, in the form of:\n"
+"\t\tafp://username;AUTH=authtype:password@server:548/volume/path\n"
+"See afpcmd(1) for more information.\n", AFPFS_VERSION
 );
 }
 

--- a/cmdline/getstatus.c
+++ b/cmdline/getstatus.c
@@ -206,7 +206,9 @@ static int getstatus(char *address_string, unsigned int port)
 
 static void usage(void)
 {
-	printf("getstatus [afp_url|ipaddress[:port]] [-i]\n");
+	printf("afpfs-ng %s - get Apple Filing Protocol server status\n"
+		"Usage:\n"
+		"\tgetstatus [afp_url|ipaddress[:port]] [-i]\n", AFPFS_VERSION);
 }
 
 int main(int argc, char *argv[])

--- a/fuse/client.c
+++ b/fuse/client.c
@@ -403,7 +403,9 @@ static int do_mount(int argc, char ** argv)
 
 static void mount_afp_usage(void)
 {
-	printf("Usage:\n     mount_afpfs [-o volpass=password] <afp url> <mountpoint>\n");
+	printf("afpfs-ng %s - mount an Apple Filing Protocol network filesystem with FUSE\n"
+	"Usage:\n"
+	"\tmount_afpfs [-o volpass=password] <afp url> <mountpoint>\n", AFPFS_VERSION);
 }
 
 static int handle_mount_afp(int argc, char * argv[])

--- a/fuse/daemon.c
+++ b/fuse/daemon.c
@@ -107,11 +107,11 @@ void close_commands(int command_fd)
 
 static void usage(void)
 {
-	printf("Usage: afpfsd [OPTION]\n"
+	printf("afpfs-ng %s - Apple Filing Protocol client FUSE daemon\n"
+"Usage: afpfsd [OPTION]\n"
 "  -l, --logmethod    Either 'syslog' or 'stdout'"
 "  -f, --foreground   Do not fork\n"
-"  -d, --debug        Does not fork, logs to stdout\n"
-"Version %s\n", AFPFS_VERSION);
+"  -d, --debug        Does not fork, logs to stdout\n", AFPFS_VERSION);
 }
 
 static int remove_other_daemon(void)

--- a/include/afp.h
+++ b/include/afp.h
@@ -15,8 +15,6 @@
 #include "afp_protocol.h"
 #include "libafpclient.h"
 
-#define AFPFS_VERSION "0.8.2"
-
 /* This is the maximum AFP version this library supports */
 #define AFP_MAX_SUPPORTED_VERSION 32
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'afpfs-ng',
   'c',
-  version: '0.8.2',
+  version: '0.9.0',
   license: 'GPLv2',
   default_options: ['warning_level=3', 'c_std=c11'],
   meson_version: '>=0.61',

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ mandir = install_prefix / get_option('mandir')
 libsearch_dirs = []
 include_dirs = []
 cflags = [
+  '-DAFPFS_VERSION="' + meson.project_version() + '"',
   '-DBINDIR=' + bindir,
   '-D_FILE_OFFSET_BITS=64',
   '-D_GNU_SOURCE',


### PR DESCRIPTION
Bump internal project version to a minor feature release point version. And, read the version string from Meson rather than hard coding in C code.

Print the afpfs-ng version string in the usage text for each app, for good measure.