### PR TITLE
Protect against race condition in main loop

### DIFF
--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -125,7 +125,7 @@ static int cmdline_getpass(void)
 	char * passwd;
 	if (strcmp(url.password,"-")==0) {
 		passwd=getpass("Password:");
-		strncpy(url.password,passwd,AFP_MAX_PASSWORD_LEN);
+		strlcpy(url.password,passwd,AFP_MAX_PASSWORD_LEN);
 	}
 	return 0;
 }
@@ -272,7 +272,7 @@ int com_pass(char * arg)
 	}
 	printf("Password set.\n");
 
-	strncpy(url.password,arg,AFP_MAX_PASSWORD_LEN);
+	strlcpy(url.password,arg,AFP_MAX_PASSWORD_LEN);
 	return 0;
 
 }
@@ -285,7 +285,7 @@ int com_user(char * arg)
 	return -1;
 	}
 
-	strncpy(url.username,arg,AFP_MAX_PASSWORD_LEN);
+	strlcpy(url.username,arg,AFP_MAX_PASSWORD_LEN);
 	printf("username is now %s\n",url.username);
 	return 0;
 }
@@ -874,7 +874,7 @@ int com_passwd(__attribute__((unused)) char * arg)
 		goto error;
 	}
 	p = getpass("New password: ");
-	strncpy(newpass,p,AFP_MAX_PASSWORD_LEN);
+	strlcpy(newpass,p,AFP_MAX_PASSWORD_LEN);
 	ret=ml_passwd(server,url.username,url.password,newpass);
 	if (ret) {
 		printf("Could not change password\n");
@@ -1257,7 +1257,7 @@ int cmdline_afp_setup(int recursive, char * url_string)
 	afp_default_url(&url);
 
 	passwd = getpwuid(getuid());
-	strncpy(url.username, passwd->pw_name,AFP_MAX_USERNAME_LEN);
+	strlcpy(url.username, passwd->pw_name,AFP_MAX_USERNAME_LEN);
 	if ((url_string) && (strlen(url_string)>1)) {
 
 

--- a/cmdline/cmdline_afp.c
+++ b/cmdline/cmdline_afp.c
@@ -140,6 +140,10 @@ static int get_server_path(char * filename, char * server_fullname)
         } else {
             result = snprintf(server_fullname, AFP_MAX_PATH, "%s/%s", curdir, filename);
         }
+		if (result >= AFP_MAX_PATH || result < 0) {
+			fprintf(stderr, "Error: Path exceeds maximum length or other error occurred.\n");
+			return -1;
+		}
     } else {
         result = snprintf(server_fullname, AFP_MAX_PATH, "%s", filename);
     }

--- a/cmdline/cmdline_main.c
+++ b/cmdline/cmdline_main.c
@@ -328,7 +328,7 @@ void * cmdline_ui(__attribute__ ((unused)) void * other)
 		Then, if there is anything left, add it to the history list
 		and execute it. */
 		s = stripwhite (line);
-		strncpy(s2,s,ARG_LEN);
+		strlcpy(s2,s,ARG_LEN);
 		if (*s) {
 			add_history (s);
 			execute_line (s2);

--- a/fuse/client.c
+++ b/fuse/client.c
@@ -430,7 +430,7 @@ static int handle_mount_afp(int argc, char * argv[])
 			memset(command,0,256);
 			
 			if ((q=strchr(p,','))) 
-				strncpy(command,p,(q-p));
+				strlcpy(command,p,(q-p));
 			else 
 				strcpy(command,p);
 

--- a/lib/uams.c
+++ b/lib/uams.c
@@ -191,7 +191,7 @@ static int cleartxt_login(struct afp_server *server, char *username, char *passw
 	else
 		p++;
 
-	strncpy(p, passwd, 8);
+	strlcpy(p, passwd, 8);
 
 	/* Send the login request on to the server. */
 	ret = afp_login(server, "Cleartxt Passwrd", ai, len, NULL);
@@ -241,7 +241,7 @@ static int cleartxt_passwd(struct afp_server *server,
 	else
 		p++;
 
-	strncpy(p, passwd, 8);
+	strlcpy(p, passwd, 8);
 
 	/* Send the login request on to the server. */
 	ret = afp_changepassword(server, "Cleartxt Passwrd", ai, len, NULL);
@@ -323,7 +323,7 @@ static int randnum_login(struct afp_server *server, char *username,
 		goto randnum_noctx_fail;
 
 	/* Copy (up to 8 characters of) the password into key_buffer. */
-	strncpy(key_buffer, passwd, sizeof(key_buffer));
+	strlcpy(key_buffer, passwd, sizeof(key_buffer));
 
 	/* Set the provided password (now in key_buffer) as the encryption
 	 * key in our established context, for subsequent use to encrypt
@@ -440,7 +440,7 @@ static int randnum2_login(struct afp_server *server, char *username, char *passw
 
 	/* Copy (up to 8 characters of) the password into key_buffer, after
 	 * zeroing it out first. */
-	strncpy(key_buffer, passwd, sizeof(key_buffer));
+	strlcpy(key_buffer, passwd, sizeof(key_buffer));
 
 	/* Rotate each byte left one bit, carrying the high bit to the next. */
 	carry = key_buffer[0] >> 7;
@@ -705,7 +705,7 @@ static int dhx_login(struct afp_server *server, char *username, char *passwd) {
 	}
 	d += nonce_len;
 	/* Copy the user's password into the plaintext. */
-	strncpy(d, passwd, 64);
+	strlcpy(d, passwd, 64);
 
 	/* Set the initialization vector for client->server transfer. */
 	ctxerror = gcry_cipher_setiv(ctx, dhx_c2siv, sizeof(dhx_c2siv));
@@ -975,7 +975,7 @@ static int dhx2_login(struct afp_server *server, char *username, char *passwd) {
 	}
 	d += sizeof(nonce_binary);
 	/* Copy the user's password into the plaintext buffer. */
-	strncpy(d, passwd, 256);
+	strlcpy(d, passwd, 256);
 
 	/* Set the initialization vector for client->server transfer. */
 	ctxerror = gcry_cipher_setiv(ctx, dhx_c2siv, sizeof(dhx_s2civ));


### PR DESCRIPTION
Signal mask for error handling, and forced memory synchronization with 1ms delay for each roundtrip.

This has a minor performance hit in my testing, but largely saves afpfsd from tripping over itself. This is the best I can do without rearchitecturing the entire thing.